### PR TITLE
Use warn in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,10 +20,35 @@ module.exports = {
         "prettier",
     ],
     "rules": {
-        "prettier/prettier": ["warn", {
-            "singleQuote": true,
-            "trailingComma": "es5",
-        }],
         "jsx-a11y/anchor-is-valid": 0,
+        "quotes": ["warn", "single", "avoid-escape"],
+        "semi": ["warn", "always"], 
+        "block-spacing": ["warn", "always"],
+        "object-curly-spacing": ["warn", "always"],
+        "array-bracket-spacing": ["warn", "never"],
+        "no-var": ["warn"],
+        "no-trailing-spaces": ["warn", {
+            "skipBlankLines": true,
+            "ignoreComments": true
+        }],
+        "no-whitespace-before-property": ["warn"],
+        "semi-spacing": "warn",
+        "semi-style": "warn",
+        "space-in-parens": ["warn", "never"],
+        "space-before-blocks": ["warn", "always"],
+        "space-before-function-paren": ["warn", {
+            "anonymous": "always",
+            "named": "never",
+            "asyncArrow": "always"
+        }],
+        "space-unary-ops": ["warn"],
+        "spaced-comment": ["warn", "always"],
+        "comma-spacing": ["warn"],
+        "comma-style": ["warn", "last"],
+        "brace-style": ["warn", "1tbs", {
+            "allowSingleLine": true
+        }],
+        "key-spacing": ["warn"],
+        "eqeqeq": ["warn", "smart"],
     },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     "rules": {
         "jsx-a11y/anchor-is-valid": 0,
         "quotes": ["warn", "single", "avoid-escape"],
-        "semi": ["warn", "always"], 
+        "semi": ["warn", "always"],
         "block-spacing": ["warn", "always"],
         "object-curly-spacing": ["warn", "always"],
         "array-bracket-spacing": ["warn", "never"],
@@ -50,5 +50,518 @@ module.exports = {
         }],
         "key-spacing": ["warn"],
         "eqeqeq": ["warn", "smart"],
+
+        'jsx-quotes': ['error', 'prefer-double'],
+
+        /**
+         * Modified from Airbnb style guideline at https://github.com/airbnb/javascript, which uses the MI[sic]T Licnese
+         * Copyright (c) 2012 Airbnb
+        Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+         */
+
+        'class-methods-use-this': ['error', {
+            exceptMethods: [
+                'render',
+                'getInitialState',
+                'getDefaultProps',
+                'getChildContext',
+                'componentWillMount',
+                'UNSAFE_componentWillMount',
+                'componentDidMount',
+                'componentWillReceiveProps',
+                'UNSAFE_componentWillReceiveProps',
+                'shouldComponentUpdate',
+                'componentWillUpdate',
+                'UNSAFE_componentWillUpdate',
+                'componentDidUpdate',
+                'componentWillUnmount',
+                'componentDidCatch',
+                'getSnapshotBeforeUpdate'
+            ],
+        }],
+
+        // Prevent missing displayName in a React component definition
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md
+        'react/display-name': ['off', { ignoreTranspilerName: false }],
+
+        // Forbid certain propTypes (any, array, object)
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/forbid-prop-types.md
+        'react/forbid-prop-types': ['warn', {
+            forbid: ['any', 'array', 'object'],
+            checkContextTypes: true,
+            checkChildContextTypes: true,
+        }],
+
+        // Forbid certain props on DOM Nodes
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/forbid-dom-props.md
+        'react/forbid-dom-props': ['off', { forbid: [] }],
+
+        // Enforce boolean attributes notation in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md
+        'react/jsx-boolean-value': ['warn', 'never', { always: [] }],
+
+        // Validate closing bracket location in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md
+        'react/jsx-closing-bracket-location': ['warn', 'line-aligned'],
+
+        // Validate closing tag location in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-tag-location.md
+        'react/jsx-closing-tag-location': 'warn',
+
+        // Enforce or disallow spaces inside of curly braces in JSX attributes
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
+        'react/jsx-curly-spacing': ['warn', 'never', { allowMultiline: true }],
+
+        // Enforce event handler naming conventions in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
+        'react/jsx-handler-names': ['off', {
+            eventHandlerPrefix: 'handle',
+            eventHandlerPropPrefix: 'on',
+        }],
+
+        // Validate props indentation in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
+        'react/jsx-indent-props': ['warn', 2],
+
+        // Validate JSX has key prop when in array or iterator
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
+        'react/jsx-key': 'off',
+
+        // Prevent usage of .bind() in JSX props
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
+        'react/jsx-no-bind': ['warn', {
+            ignoreRefs: true,
+            allowArrowFunctions: true,
+            allowFunctions: false,
+            allowBind: false,
+            ignoreDOMComponents: true,
+        }],
+
+        // Prevent duplicate props in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md
+        'react/jsx-no-duplicate-props': ['warn', { ignoreCase: true }],
+
+        // Prevent usage of unwrapped JSX strings
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md
+        'react/jsx-no-literals': ['off', { noStrings: true }],
+
+        // Disallow undeclared variables in JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-undef.md
+        'react/jsx-no-undef': 'error',
+
+        // Enforce PascalCase for user-defined JSX components
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
+        'react/jsx-pascal-case': ['warn', {
+            allowAllCaps: true,
+            ignore: [],
+        }],
+
+        // Enforce propTypes declarations alphabetical sorting
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-prop-types.md
+        'react/sort-prop-types': ['off', {
+            ignoreCase: true,
+            callbacksLast: false,
+            requiredFirst: false,
+            sortShapeProp: true,
+        }],
+
+        // Deprecated in favor of react/jsx-sort-props
+        'react/jsx-sort-prop-types': 'off',
+
+        // Enforce props alphabetical sorting
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md
+        'react/jsx-sort-props': ['off', {
+            ignoreCase: true,
+            callbacksLast: false,
+            shorthandFirst: false,
+            shorthandLast: false,
+            noSortAlphabetically: false,
+            reservedFirst: true,
+        }],
+
+        // Enforce defaultProps declarations alphabetical sorting
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/jsx-sort-default-props.md
+        'react/jsx-sort-default-props': ['off', {
+            ignoreCase: true,
+        }],
+
+        // Prevent React to be incorrectly marked as unused
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
+        'react/jsx-uses-react': ['warn'],
+
+        // Prevent variables used in JSX to be incorrectly marked as unused
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
+        'react/jsx-uses-vars': 'warn',
+
+        // Prevent usage of dangerous JSX properties
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger.md
+        'react/no-danger': 'warn',
+
+        // Prevent usage of deprecated methods
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md
+        'react/no-deprecated': ['warn'],
+
+        // Prevent usage of setState in componentDidMount
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
+        // this is necessary for server-rendering
+        'react/no-did-mount-set-state': 'off',
+
+        // Prevent usage of setState in componentDidUpdate
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
+        'react/no-did-update-set-state': 'error',
+
+        // Prevent usage of setState in componentWillUpdate
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md
+        'react/no-will-update-set-state': 'error',
+
+        // Prevent direct mutation of this.state
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
+        'react/no-direct-mutation-state': 'off',
+
+        // Prevent usage of isMounted
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md
+        'react/no-is-mounted': 'error',
+
+        // Prevent multiple component definition per file
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
+        'react/no-multi-comp': 'off',
+
+        // Prevent usage of setState
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-set-state.md
+        'react/no-set-state': 'off',
+
+        // Prevent using string references
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
+        'react/no-string-refs': 'warn',
+
+        // Prevent usage of unknown DOM property
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
+        'react/no-unknown-property': 'warn',
+
+        // Require ES6 class declarations over React.createClass
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
+        'react/prefer-es6-class': ['warn', 'always'],
+
+        // Require stateless functions when not using lifecycle methods, setState or ref
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
+        'react/prefer-stateless-function': ['error', { ignorePureComponents: true }],
+
+        // Prevent missing props validation in a React component definition
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
+        'react/prop-types': ['warn', {
+            ignore: [],
+            customValidators: [],
+            skipUndeclared: false
+        }],
+
+        // Prevent missing React when using JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
+        'react/react-in-jsx-scope': 'error',
+
+        // Require render() methods to return something
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md
+        'react/require-render-return': 'error',
+
+        // Prevent extra closing tags for components without children
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
+        'react/self-closing-comp': 'warn',
+
+        // Enforce component methods order
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/sort-comp.md
+        'react/sort-comp': ['warn', {
+            order: [
+                'static-variables',
+                'static-methods',
+                'instance-variables',
+                'lifecycle',
+                '/^on.+$/',
+                'getters',
+                'setters',
+                '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
+                'instance-methods',
+                'everything-else',
+                'rendering',
+            ],
+            groups: {
+                lifecycle: [
+                    'displayName',
+                    'propTypes',
+                    'contextTypes',
+                    'childContextTypes',
+                    'mixins',
+                    'statics',
+                    'defaultProps',
+                    'constructor',
+                    'getDefaultProps',
+                    'getInitialState',
+                    'state',
+                    'getChildContext',
+                    'getDerivedStateFromProps',
+                    'componentWillMount',
+                    'UNSAFE_componentWillMount',
+                    'componentDidMount',
+                    'componentWillReceiveProps',
+                    'UNSAFE_componentWillReceiveProps',
+                    'shouldComponentUpdate',
+                    'componentWillUpdate',
+                    'UNSAFE_componentWillUpdate',
+                    'getSnapshotBeforeUpdate',
+                    'componentDidUpdate',
+                    'componentDidCatch',
+                    'componentWillUnmount'
+                ],
+                rendering: [
+                    '/^render.+$/',
+                    'render'
+                ],
+            },
+        }],
+
+        // Prevent missing parentheses around multilines JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/jsx-wrap-multilines.md
+        'react/jsx-wrap-multilines': ['warn', {
+            declaration: 'parens-new-line',
+            assignment: 'parens-new-line',
+            return: 'parens-new-line',
+            arrow: 'parens-new-line',
+            condition: 'parens-new-line',
+            logical: 'parens-new-line',
+            prop: 'parens-new-line',
+        }],
+
+        // Require that the first prop in a JSX element be on a new line when the element is multiline
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
+        'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
+
+        // Enforce spacing around jsx equals signs
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md
+        'react/jsx-equals-spacing': ['warn', 'never'],
+
+        // Enforce JSX indentation
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
+        'react/jsx-indent': ['warn', 2],
+
+        // Disallow target="_blank" on links
+        // https://github.com/yannickcr/eslint-plugin-react/blob/ac102885765be5ff37847a871f239c6703e1c7cc/docs/rules/jsx-no-target-blank.md
+        'react/jsx-no-target-blank': ['warn', { enforceDynamicLinks: 'always' }],
+
+        // only .jsx files may have JSX
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
+        'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
+
+        // prevent accidental JS comments from being injected into JSX as text
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md
+        'react/jsx-no-comment-textnodes': 'error',
+
+        // disallow using React.render/ReactDOM.render's return value
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md
+        'react/no-render-return-value': 'error',
+
+        // require a shouldComponentUpdate method, or PureRenderMixin
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-optimization.md
+        'react/require-optimization': ['off', { allowDecorators: [] }],
+
+        // warn against using findDOMNode()
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md
+        'react/no-find-dom-node': 'error',
+
+        // Forbid certain props on Components
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-component-props.md
+        'react/forbid-component-props': ['off', { forbid: [] }],
+
+        // Forbid certain elements
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md
+        'react/forbid-elements': ['off', { forbid: [], }],
+
+        // Prevent problem with children and props.dangerouslySetInnerHTML
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md
+        'react/no-danger-with-children': 'error',
+
+        // Prevent unused propType definitions
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md
+        'react/no-unused-prop-types': ['warn', {
+            customValidators: [
+            ],
+            skipShapeProps: true,
+        }],
+
+        // Require style prop value be an object or var
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/style-prop-object.md
+        'react/style-prop-object': 'error',
+
+        // Prevent invalid characters from appearing in markup
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md
+        'react/no-unescaped-entities': 'error',
+
+        // Prevent passing of children as props
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md
+        'react/no-children-prop': 'error',
+
+        // Validate whitespace in and around the JSX opening and closing brackets
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/jsx-tag-spacing.md
+        'react/jsx-tag-spacing': ['warn', {
+            closingSlash: 'never',
+            beforeSelfClosing: 'always',
+            afterOpening: 'never',
+            beforeClosing: 'never',
+        }],
+
+        // Enforce spaces before the closing bracket of self-closing JSX elements
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
+        // Deprecated in favor of jsx-tag-spacing
+        'react/jsx-space-before-closing': ['off', 'always'],
+
+        // Prevent usage of Array index in keys
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md
+        'react/no-array-index-key': 'error',
+
+        // Enforce a defaultProps definition for every prop that is not a required prop
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/require-default-props.md
+        'react/require-default-props': ['error', {
+            forbidDefaultForRequired: true,
+        }],
+
+        // Forbids using non-exported propTypes
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md
+        // this is intentionally set to "warn". it would be "error",
+        // but it's only critical if you're stripping propTypes in production.
+        'react/forbid-foreign-prop-types': ['warn', { allowInPropTypes: true }],
+
+        // Prevent void DOM elements from receiving children
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md
+        'react/void-dom-elements-no-children': 'error',
+
+        // Enforce all defaultProps have a corresponding non-required PropType
+        // https://github.com/yannickcr/eslint-plugin-react/blob/9e13ae2c51e44872b45cc15bf1ac3a72105bdd0e/docs/rules/default-props-match-prop-types.md
+        'react/default-props-match-prop-types': ['error', { allowRequiredDefaults: false }],
+
+        // Prevent usage of shouldComponentUpdate when extending React.PureComponent
+        // https://github.com/yannickcr/eslint-plugin-react/blob/9e13ae2c51e44872b45cc15bf1ac3a72105bdd0e/docs/rules/no-redundant-should-component-update.md
+        'react/no-redundant-should-component-update': 'error',
+
+        // Prevent unused state values
+        // https://github.com/yannickcr/eslint-plugin-react/pull/1103/
+        'react/no-unused-state': 'warn',
+
+        // Enforces consistent naming for boolean props
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/boolean-prop-naming.md
+        'react/boolean-prop-naming': ['off', {
+            propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
+            rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+',
+            message: '',
+        }],
+
+        // Prevents common casing typos
+        // https://github.com/yannickcr/eslint-plugin-react/blob/73abadb697034b5ccb514d79fb4689836fe61f91/docs/rules/no-typos.md
+        'react/no-typos': 'error',
+
+        // Enforce curly braces or disallow unnecessary curly braces in JSX props and/or children
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md
+        'react/jsx-curly-brace-presence': ['warn', { props: 'never', children: 'never' }],
+
+        // One JSX Element Per Line
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/jsx-one-expression-per-line.md
+        'react/jsx-one-expression-per-line': ['off', { allow: 'single-child' }],
+
+        // Enforce consistent usage of destructuring assignment of props, state, and context
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/destructuring-assignment.md
+        'react/destructuring-assignment': ['warn', 'always'],
+
+        // Prevent using this.state within a this.setState
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/no-access-state-in-setstate.md
+        'react/no-access-state-in-setstate': 'error',
+
+        // Prevent usage of button elements without an explicit type attribute
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/button-has-type.md
+        'react/button-has-type': ['warn', {
+            button: true,
+            submit: true,
+            reset: false,
+        }],
+
+        // Ensures inline tags are not rendered without spaces between them
+        'react/jsx-child-element-spacing': 'off',
+
+        // Prevent this from being used in stateless functional components
+        // https://github.com/yannickcr/eslint-plugin-react/blob/843d71a432baf0f01f598d7cf1eea75ad6896e4b/docs/rules/no-this-in-sfc.md
+        'react/no-this-in-sfc': 'error',
+
+        // Validate JSX maximum depth
+        // https://github.com/yannickcr/eslint-plugin-react/blob/abe8381c0d6748047224c430ce47f02e40160ed0/docs/rules/jsx-max-depth.md
+        'react/jsx-max-depth': 'off',
+
+        // Disallow multiple spaces between inline JSX props
+        // https://github.com/yannickcr/eslint-plugin-react/blob/ac102885765be5ff37847a871f239c6703e1c7cc/docs/rules/jsx-props-no-multi-spaces.md
+        'react/jsx-props-no-multi-spaces': 'warn',
+
+        // Prevent usage of UNSAFE_ methods
+        // https://github.com/yannickcr/eslint-plugin-react/blob/157cc932be2cfaa56b3f5b45df6f6d4322a2f660/docs/rules/no-unsafe.md
+        'react/no-unsafe': 'off',
+
+        // Enforce shorthand or standard form for React fragments
+        // https://github.com/yannickcr/eslint-plugin-react/blob/bc976b837abeab1dffd90ac6168b746a83fc83cc/docs/rules/jsx-fragments.md
+        'react/jsx-fragments': ['warn', 'syntax'],
+
+        // Enforce linebreaks in curly braces in JSX attributes and expressions.
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-newline.md
+        'react/jsx-curly-newline': ['warn', {
+            multiline: 'consistent',
+            singleline: 'consistent',
+        }],
+
+        // Enforce state initialization style
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/state-in-constructor.md
+        // TODO: set to "never" once babel-preset-airbnb supports public class fields
+        'react/state-in-constructor': ['off', 'always'],
+
+        // Enforces where React component static properties should be positioned
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/static-property-placement.md
+        // TODO: set to "static public field" once babel-preset-airbnb supports public class fields
+        'react/static-property-placement': ['warn', 'property assignment'],
+
+        // Disallow JSX props spreading
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md
+        'react/jsx-props-no-spreading': ['off', {
+            html: 'enforce',
+            custom: 'enforce',
+            exceptions: [],
+        }],
+
+        // Enforce that props are read-only
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prefer-read-only-props.md
+        'react/prefer-read-only-props': 'off',
+
+        // Prevent usage of `javascript:` URLs
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-script-url.md
+        // TODO: enable, semver-major
+        'react/jsx-no-script-url': ['off', [
+            {
+                name: 'Link',
+                props: ['to'],
+            },
+        ]],
+
+        // Disallow unnecessary fragments
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md
+        // TODO: enable, semver-major
+        'react/jsx-no-useless-fragment': 'off',
+
+        // Prevent adjacent inline elements not separated by whitespace
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-adjacent-inline-elements.md
+        // TODO: enable? semver-major
+        'react/no-adjacent-inline-elements': 'off',
+
+        // Enforce a specific function type for function components
+        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/function-component-definition.md
+        // TODO: enable! semver-minor, but do it in a major to be safe
+        // TODO: investigate if setting namedComponents to expression vs declaration is problematic
+        'react/function-component-definition': ['off', {
+            namedComponents: 'function-expression',
+            unnamedComponents: 'function-expression',
+        }],
     },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
         "browser": true,
         "es6": true
     },
-    "extends": "airbnb",
+    "extends": "react-app",
     "globals": {
         "Atomics": "readonly",
         "SharedArrayBuffer": "readonly"
@@ -16,10 +16,14 @@ module.exports = {
         "sourceType": "module"
     },
     "plugins": [
-        "react"
+        "react",
+        "prettier",
     ],
     "rules": {
-	    "react/jsx-props-no-spreading": ["warn", {"custom": "ignore"}],
+        "prettier/prettier": ["warn", {
+            "singleQuote": true,
+            "trailingComma": "es5",
+        }],
         "jsx-a11y/anchor-is-valid": 0,
     },
 };

--- a/client/actions/.eslintrc.json
+++ b/client/actions/.eslintrc.json
@@ -4,8 +4,6 @@
         "es6": true
     },
     "extends": [
-        "airbnb-base",
-        "prettier"
     ],
     "plugins": [
         "prettier"
@@ -19,12 +17,5 @@
         "sourceType": "module"
     },
     "rules": {
-        "prettier/prettier": ["warn"],
-        "linebreak-style": 0,
-        "no-underscore-dangle": "off",
-        "import/prefer-default-export": "off",
-        "no-trailing-spaces": ["warn", {
-            "ignoreComments": true
-        }]
     }
 }

--- a/client/actions/api.js
+++ b/client/actions/api.js
@@ -1,5 +1,5 @@
-import fetch from "isomorphic-unfetch";
-import urls from "../../utils/urls";
+import fetch from 'isomorphic-unfetch';
+import urls from '../../utils/urls';
 
 /**
  * @typedef {{ url: string, fileName: string, views: number, category: string }} pdf
@@ -13,14 +13,14 @@ import urls from "../../utils/urls";
  */
 export const getPDF = () =>
   fetch(urls.baseUrl + urls.api.getPDF, {
-    method: "get",
-    mode: "no-cors",
-    credentials: "include"
+    method: 'get',
+    mode: 'no-cors',
+    credentials: 'include'
   })
     .then(response => response.json())
     .then(json => {
       if (json == null) {
-        throw new Error("Could not connect to API!");
+        throw new Error('Could not connect to API!');
       } else if (!json.success) {
         throw new Error(json.message);
       }
@@ -36,11 +36,11 @@ export const getPDF = () =>
  */
 export const updateClicks = (category, fileName) => {
   fetch(urls.baseUrl + urls.api.updateClicks, {
-    method: "post",
-    mode: "no-cors",
-    credentials: "include",
+    method: 'post',
+    mode: 'no-cors',
+    credentials: 'include',
     headers: {
-      "Content-Type": "application/json"
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({
       category,
@@ -50,7 +50,7 @@ export const updateClicks = (category, fileName) => {
     .then(response => response.json())
     .then(json => {
       if (json == null) {
-        throw new Error("Could not connect to API!");
+        throw new Error('Could not connect to API!');
       } else if (!json.success) {
         throw new Error(json.message);
       }
@@ -66,14 +66,14 @@ export const updateClicks = (category, fileName) => {
  */
 export const getCategories = () =>
   fetch(urls.baseUrl + urls.api.categories, {
-    method: "get",
-    mode: "no-cors",
-    credentials: "include"
+    method: 'get',
+    mode: 'no-cors',
+    credentials: 'include'
   })
     .then(response => response.json())
     .then(json => {
       if (json == null) {
-        throw new Error("Could not connect to API!");
+        throw new Error('Could not connect to API!');
       } else if (!json.success) {
         throw new Error(json.message);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -935,13 +935,21 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.4.tgz",
-      "integrity": "sha512-+wpLqy5+fbQhvbllvlJEVRIpYj+COUWnnsm+I4jZlA8Lo7/MJmBhGTCHyk1/RWfOqBRJ2MbadddG6QltTKTlrg==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
+      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+          "dev": true
+        }
       }
     },
     "@babel/template": {
@@ -1316,6 +1324,12 @@
         "@types/node": "*"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1352,43 +1366,81 @@
         "csstype": "^2.2.0"
       }
     },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.23.0.tgz",
+      "integrity": "sha512-8iA4FvRsz8qTjR0L/nK9RcRUN3QtIHQiOm69FzV7WS3SE+7P7DyGGwh3k4UNR2JBbk+Ej2Io+jLAaqKibNhmtw==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "2.23.0",
+        "eslint-utils": "^1.4.3",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
+      }
+    },
     "@typescript-eslint/experimental-utils": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
-      "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz",
+      "integrity": "sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-scope": "^4.0.0"
+        "@typescript-eslint/typescript-estree": "2.23.0",
+        "eslint-scope": "^5.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
+          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
       }
     },
     "@typescript-eslint/parser": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
-      "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.23.0.tgz",
+      "integrity": "sha512-k61pn/Nepk43qa1oLMiyqApC6x5eP5ddPz6VUYXCAuXxbmRLqkPYzkFRKl42ltxzB2luvejlVncrEpflgQoSUg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "1.13.0",
-        "@typescript-eslint/typescript-estree": "1.13.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "@typescript-eslint/experimental-utils": "2.23.0",
+        "@typescript-eslint/typescript-estree": "2.23.0",
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
-      "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz",
+      "integrity": "sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==",
       "dev": true,
       "requires": {
-        "lodash.unescape": "4.0.1",
-        "semver": "5.5.0"
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
       },
       "dependencies": {
         "semver": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -1637,12 +1689,20 @@
       "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
     },
     "ansi-escapes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
-      "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "requires": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
       }
     },
     "ansi-html": {
@@ -1871,25 +1931,10 @@
       }
     },
     "axobject-query": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
-      "integrity": "sha512-lF98xa/yvy6j3fBHAgQXIYl+J4eZadOSqsPojemUqClzNbBV38wWGpUbQbVEyf4eUF5yF7eHmGgGA2JiHyjeqw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.7.4",
-        "@babel/runtime-corejs3": "^7.7.4"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.8.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.4.tgz",
-          "integrity": "sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==",
-          "dev": true,
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
+      "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1942,6 +1987,20 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg=="
+    },
+    "babel-eslint": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
+      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.7.0",
+        "@babel/traverse": "^7.7.0",
+        "@babel/types": "^7.7.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
     },
     "babel-loader": {
       "version": "8.0.6",
@@ -3498,9 +3557,9 @@
           }
         },
         "globals": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
@@ -3561,6 +3620,15 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-config-react-app": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.2.0.tgz",
+      "integrity": "sha512-WrHjoGpKr1kLLiWDD81tme9jMM0hk5cMxasLSdyno6DdPt+IfLOrDJBVo6jN7tn4y1nzhs43TmUaZWO6Sf0blw==",
+      "dev": true,
+      "requires": {
+        "confusing-browser-globals": "^1.0.9"
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
@@ -3613,6 +3681,15 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-flowtype": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-4.6.0.tgz",
+      "integrity": "sha512-W5hLjpFfZyZsXfo5anlu7HM970JBDqbEshAJUkeczP6BFCIfJXuiIBQXyberLRtOStT0OGPF8efeTbxlHk4LpQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "eslint-plugin-import": {
@@ -3697,9 +3774,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.3.tgz",
-      "integrity": "sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
+      "integrity": "sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -3710,8 +3787,10 @@
         "object.fromentries": "^2.0.2",
         "object.values": "^1.1.1",
         "prop-types": "^15.7.2",
-        "resolve": "^1.14.2",
-        "string.prototype.matchall": "^4.0.2"
+        "resolve": "^1.15.1",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.2",
+        "xregexp": "^4.3.0"
       },
       "dependencies": {
         "doctrine": {
@@ -3722,13 +3801,28 @@
           "requires": {
             "esutils": "^2.0.2"
           }
+        },
+        "resolve": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.0.tgz",
+      "integrity": "sha512-bzvdX47Jx847bgAYf0FPX3u1oxU+mKU8tqrpj4UX9A96SbAmj/HVEefEy6rJUog5u8QIlOPTKZcBpGn5kkKfAQ==",
       "dev": true
     },
     "eslint-scope": {
@@ -3756,20 +3850,26 @@
       "dev": true
     },
     "espree": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.1.2.tgz",
-      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
-        "acorn-jsx": "^5.1.0",
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-          "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+          "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+          "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
           "dev": true
         }
       }
@@ -4010,9 +4110,9 @@
       "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
     },
     "figures": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
-      "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -4996,26 +5096,52 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inquirer": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.4.tgz",
-      "integrity": "sha512-Bu5Td5+j11sCkqfqmUTiwv+tWisMtP0L7Q8WrqA2C/BbBhy1YTdFrvjjlrKq8oagA/tLQBski2Gcx/Sqyi2qSQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^2.4.2",
+        "chalk": "^3.0.0",
         "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
         "lodash": "^4.17.15",
         "mute-stream": "0.0.8",
-        "run-async": "^2.2.0",
+        "run-async": "^2.4.0",
         "rxjs": "^6.5.3",
         "string-width": "^4.1.0",
-        "strip-ansi": "^5.1.0",
+        "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
         "cli-cursor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -5024,6 +5150,27 @@
           "requires": {
             "restore-cursor": "^3.1.0"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "mimic-fn": {
           "version": "2.1.0",
@@ -5048,6 +5195,33 @@
           "requires": {
             "onetime": "^5.1.0",
             "signal-exit": "^3.0.2"
+          }
+        },
+        "run-async": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.0.tgz",
+          "integrity": "sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==",
+          "dev": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -7358,6 +7532,47 @@
         "vue-eslint-parser": "^2.0.2"
       },
       "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-1.13.0.tgz",
+          "integrity": "sha512-zmpS6SyqG4ZF64ffaJ6uah6tWWWgZ8m+c54XXgwFtUv0jNz8aJAVx8chMCvnk7yl6xwn8d+d96+tWp7fXzTuDg==",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.3",
+            "@typescript-eslint/typescript-estree": "1.13.0",
+            "eslint-scope": "^4.0.0"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-1.13.0.tgz",
+          "integrity": "sha512-ITMBs52PCPgLb2nGPoeT4iU3HdQZHcPaZVw+7CsFagRJHUhyeTgorEwHXhFf3e7Evzi8oujKNpHc8TONth8AdQ==",
+          "dev": true,
+          "requires": {
+            "@types/eslint-visitor-keys": "^1.0.0",
+            "@typescript-eslint/experimental-utils": "1.13.0",
+            "@typescript-eslint/typescript-estree": "1.13.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-1.13.0.tgz",
+          "integrity": "sha512-b5rCmd2e6DCC6tCTN9GSUAuxdYwCM/k/2wdjHGrIRGPSJotWMCe/dGpi66u42bhuh8q3QBzqM4TMA1GUUCJvdw==",
+          "dev": true,
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.5.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+              "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+              "dev": true
+            }
+          }
+        },
         "ansi-escapes": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -9117,6 +9332,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
     "tty-browserify": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
@@ -9611,7 +9835,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9629,11 +9854,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9646,15 +9873,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9757,7 +9987,8 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9767,6 +9998,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9779,17 +10011,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9806,6 +10041,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9886,7 +10122,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9896,6 +10133,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9971,7 +10209,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10001,6 +10240,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10018,6 +10258,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10056,11 +10297,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -10340,6 +10583,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
       "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
+    "xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.8.3"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -37,14 +37,19 @@
     "xhr2": "^0.2.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.23.0",
+    "@typescript-eslint/parser": "^2.23.0",
+    "babel-eslint": "^10.1.0",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-prettier": "^6.9.0",
+    "eslint-config-react-app": "^5.2.0",
+    "eslint-plugin-flowtype": "^4.6.0",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",
-    "eslint-plugin-react": "^7.18.3",
-    "eslint-plugin-react-hooks": "^1.7.0",
+    "eslint-plugin-react": "^7.19.0",
+    "eslint-plugin-react-hooks": "^2.5.0",
     "prettier": "1.19.1",
     "prettier-eslint": "^9.0.1"
   }

--- a/pages/api/.eslintrc.json
+++ b/pages/api/.eslintrc.json
@@ -4,8 +4,6 @@
         "node": true
     },
     "extends": [
-        "airbnb-base",
-        "prettier"
     ],
     "plugins": [
         "prettier"
@@ -19,13 +17,5 @@
         "sourceType": "module"
     },
     "rules": {
-        "prettier/prettier": ["error"],
-        "linebreak-style": 0,
-        "no-underscore-dangle": "off",
-        "no-console": "off",
-        "import/prefer-default-export": "off",
-        "no-trailing-spaces": ["warn", {
-            "ignoreComments": true
-        }]
     }
 }

--- a/pages/api/getCategories.js
+++ b/pages/api/getCategories.js
@@ -1,4 +1,4 @@
-import { getCategories } from "../../server/actions/database";
+import { getCategories } from '../../server/actions/database';
 
 /**
  * Get a list of all categories and the PDFs in those categories. The response sends JSON in the format of {[category: string]: { fileName: string, views: number }[]}.
@@ -21,7 +21,7 @@ const handler = (req, res) =>
     .catch(() =>
       res.status(201).json({
         success: false,
-        message: "Failed to run action!"
+        message: 'Failed to run action!'
       })
     );
 

--- a/pages/api/getPDF.js
+++ b/pages/api/getPDF.js
@@ -1,4 +1,4 @@
-import { getPDF } from "../../server/actions/database";
+import { getPDF } from '../../server/actions/database';
 
 /**
  * Get all PDFs. Sends JSON in the format of {success: boolean, payload: {pdfMap: Object.<[category: string], pdf[]>, sortedPdfs: pdf[]}}, where pdf is in the format of { url: string, fileName: string, views: number, category: string }
@@ -22,7 +22,7 @@ const handler = (req, res) =>
     .catch(() =>
       res.status(201).json({
         success: false,
-        message: "Failed to run action!"
+        message: 'Failed to run action!'
       })
     );
 

--- a/pages/api/updateClicks.js
+++ b/pages/api/updateClicks.js
@@ -1,4 +1,4 @@
-import { updateClicks } from "../../server/actions/database";
+import { updateClicks } from '../../server/actions/database';
 
 /**
  * Increment clicks for a PDF given its category and file name.
@@ -25,7 +25,7 @@ const handler = (req, res) => {
     .catch(() =>
       res.status(201).json({
         success: false,
-        message: "Failed to run action!"
+        message: 'Failed to run action!'
       })
     );
 };

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -4,8 +4,6 @@
         "node": true
     },
     "extends": [
-        "airbnb-base",
-        "prettier"
     ],
     "plugins": [
         "prettier"
@@ -19,13 +17,5 @@
         "sourceType": "module"
     },
     "rules": {
-        "prettier/prettier": ["error"],
-        "linebreak-style": 0,
-        "no-underscore-dangle": "off",
-        "no-console": "off",
-        "import/prefer-default-export": "off",
-        "no-trailing-spaces": ["warn", {
-            "ignoreComments": true
-        }]
     }
 }

--- a/server/actions/database.js
+++ b/server/actions/database.js
@@ -1,21 +1,21 @@
-import firebase from "firebase";
-import "firebase/storage";
-import "firebase/firestore";
+import firebase from 'firebase';
+import 'firebase/storage';
+import 'firebase/firestore';
 
-global.XMLHttpRequest = require("xhr2");
+global.XMLHttpRequest = require('xhr2');
 
 if (!firebase.apps.length) {
   const firebaseConfig = {
-    apiKey: "AIzaSyDu2fblA5PCmdknt6reohIMeOlqgf-B1No",
+    apiKey: 'AIzaSyDu2fblA5PCmdknt6reohIMeOlqgf-B1No',
     // authDomain: '<your-auth-domain>',
-    projectId: "ombudsman-a8077",
-    storageBucket: "gs://ombudsman-a8077.appspot.com"
+    projectId: 'ombudsman-a8077',
+    storageBucket: 'gs://ombudsman-a8077.appspot.com'
   };
   firebase.initializeApp(firebaseConfig);
 }
 const storage = firebase.storage();
 const firestore = firebase.firestore();
-const dbCategory = "catArray";
+const dbCategory = 'catArray';
 
 /**
  * @typedef {{ url: string, fileName: string, views: number, category: string }} pdf Note that url refers to the image URL.
@@ -28,7 +28,7 @@ const dbCategory = "catArray";
  * @returns {Promise<{[category: string]: pdfLite[]}>} object mapping categories to a list of PDF property objects
  */
 export const getCategories = async () => {
-  const firestoreRef = firestore.collection("categories").doc("categories");
+  const firestoreRef = firestore.collection('categories').doc('categories');
   let categories = [];
   const doc = await firestoreRef.get();
   categories = doc.data()[dbCategory];
@@ -42,7 +42,7 @@ export const getCategories = async () => {
  * @param {string} fileName file name
  */
 export const updateClicks = async (category, fileName) => {
-  const firestoreRef = firestore.collection("categories").doc("categories");
+  const firestoreRef = firestore.collection('categories').doc('categories');
   const updateKey = `catArray.${[category]}.${[fileName]}.views`;
   firestoreRef.update(updateKey, firebase.firestore.FieldValue.increment(1));
 };
@@ -75,7 +75,7 @@ export const getPDF = async () => {
       let views = 0;
       if (
         file.name.slice(0, -4) in categoryMap[category] &&
-        "views" in categoryMap[category][file.name.slice(0, -4)]
+        'views' in categoryMap[category][file.name.slice(0, -4)]
       ) {
         views = categoryMap[category][file.name.slice(0, -4)].views;
       }


### PR DESCRIPTION
Copy-pasted in the Airbnb style guideline, setting the less important style guidelines to "warn" instead of "error". This is also extending the [react-app style guidelines](https://github.com/facebook/create-react-app/tree/master/packages/eslint-config-react-app). Manually added in some spacing style guidelines, set to warn. Ran `npm run lint` so that replaces some double quotes with single quotes. Removed prettier. This introduces new dependencies, so run `npm install`. Didn't remove the unused dependencies.